### PR TITLE
Fix path not correct issue if there is no build parameters

### DIFF
--- a/aiojenkins/builds.py
+++ b/aiojenkins/builds.py
@@ -154,10 +154,7 @@ class Builds:
         """
         folder_name, job_name = self.jenkins._get_folder_and_job_name(name)
 
-        path = '/{}/job/{}'.format(
-            folder_name,
-            job_name
-        )
+        path = '/{}/job/{}'.format(folder_name, job_name)
 
         data = None
 

--- a/aiojenkins/builds.py
+++ b/aiojenkins/builds.py
@@ -179,9 +179,9 @@ class Builds:
                 **parameters,
             }
 
-            path += "/buildWithParameters"
+            path += '/buildWithParameters'
         else:
-            path += "/build"
+            path += '/build'
 
         response = await self.jenkins._request(
             'POST',

--- a/aiojenkins/builds.py
+++ b/aiojenkins/builds.py
@@ -154,13 +154,14 @@ class Builds:
         """
         folder_name, job_name = self.jenkins._get_folder_and_job_name(name)
 
+        path = '/{}/job/{}/buildWithParameters'.format(
+            folder_name,
+            job_name
+        )
+
         data = None
 
         if parameters:
-            path = '/{}/job/{}/buildWithParameters'.format(
-                folder_name,
-                job_name
-            )
 
             formatted_parameters = [
                 {'name': k, 'value': str(v)} for k, v in parameters.items()
@@ -177,8 +178,6 @@ class Builds:
                 }),
                 **parameters,
             }
-        else:
-            path = '/job/{}/build'.format(name)
 
         response = await self.jenkins._request(
             'POST',

--- a/aiojenkins/builds.py
+++ b/aiojenkins/builds.py
@@ -154,7 +154,7 @@ class Builds:
         """
         folder_name, job_name = self.jenkins._get_folder_and_job_name(name)
 
-        path = '/{}/job/{}/buildWithParameters'.format(
+        path = '/{}/job/{}'.format(
             folder_name,
             job_name
         )
@@ -178,6 +178,10 @@ class Builds:
                 }),
                 **parameters,
             }
+
+            path += "/buildWithParameters"
+        else:
+            path += "/build"
 
         response = await self.jenkins._request(
             'POST',


### PR DESCRIPTION
when building a job, the job path should be same no matter having parameters or not.