### PR TITLE
Use attribute 'temporarilyOffline' instead 'offline' for enabling/disabling nodes.

### DIFF
--- a/aiojenkins/nodes.py
+++ b/aiojenkins/nodes.py
@@ -267,7 +267,7 @@ class Nodes:
             None
         """
         info = await self.get_info(name)
-        if not info['offline']:
+        if not info['temporarilyOffline']:
             return
 
         name = self._normalize_name(name)
@@ -288,7 +288,7 @@ class Nodes:
             None
         """
         info = await self.get_info(name)
-        if info['offline']:
+        if info['temporarilyOffline']:
             return
 
         name = self._normalize_name(name)


### PR DESCRIPTION
Using the 'offline' attribute to decide whether to toggle the state of nodes on activation/deactivation results in incorrect behavior. If a previously activated node is offline, e.g. because there is no connection, and you use the noce enable function, it will be actually deactivated. The attribute 'temporarilyOffline' must be used instead.

Also see https://github.com/pbelskiy/ujenkins/pull/9.