### PR TITLE
Make Jenkins implement AbstractAsyncContextManager + Improve tests/README to use it

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,17 +44,11 @@ Start new build:
     import asyncio
     import aiojenkins
 
-    jenkins = aiojenkins.Jenkins('http://your_server/jenkins', 'user', 'password')
-
     async def example():
-        await jenkins.builds.start('job_name', dict(parameter='test'))
+        async with aiojenkins.Jenkins('http://your_server/jenkins', 'user', 'password') as jenkins:
+            await jenkins.builds.start('job_name', dict(parameter='test'))
 
-    loop = asyncio.get_event_loop()
-    try:
-        loop.run_until_complete(example())
-    finally:
-        loop.run_until_complete(jenkins.close())
-        loop.close()
+    asyncio.run(example())
 
 `Please look at tests directory for more examples. <https://github.com/pbelskiy/aiojenkins/tree/master/tests>`_
 

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Start new build:
 
     async def example():
         async with aiojenkins.Jenkins('http://your_server/jenkins', 'user', 'password') as jenkins:
-            await jenkins.builds.start('job_name', {'parameter':'test'})
+            await jenkins.builds.start('job_name', {'parameter': 'test'})
 
     asyncio.run(example())
 

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Installation
 Usage
 -----
 
-Start new build:
+Start new build using `aiojenkins.Jenkins` as an async context manager (preferred):
 
 .. code:: python
 
@@ -47,6 +47,23 @@ Start new build:
     async def example():
         async with aiojenkins.Jenkins('http://your_server/jenkins', 'user', 'password') as jenkins:
             await jenkins.builds.start('job_name', {'parameter': 'test'})
+
+    asyncio.run(example())
+
+Or without an async context manager:
+
+.. code:: python
+
+    import asyncio
+    import aiojenkins
+
+    jenkins = aiojenkins.Jenkins('http://your_server/jenkins', 'user', 'password')
+
+    async def example():
+        try:
+            await jenkins.builds.start('job_name', {'parameter': 'test'})
+        finally:
+            jenkins.close()
 
     asyncio.run(example())
 

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Start new build:
 
     async def example():
         async with aiojenkins.Jenkins('http://your_server/jenkins', 'user', 'password') as jenkins:
-            await jenkins.builds.start('job_name', dict(parameter='test'))
+            await jenkins.builds.start('job_name', {'parameter':'test'})
 
     asyncio.run(example())
 

--- a/aiojenkins/jenkins.py
+++ b/aiojenkins/jenkins.py
@@ -1,5 +1,6 @@
 import asyncio
 
+from contextlib import AbstractAsyncContextManager
 from http import HTTPStatus
 from typing import Any, NamedTuple, Optional, Tuple, Union
 
@@ -66,7 +67,7 @@ class RetryClientSession:
         await self.session.close()
 
 
-class Jenkins:
+class Jenkins(AbstractAsyncContextManager):
 
     _session = None
 
@@ -417,3 +418,9 @@ class Jenkins:
         )
 
         return await response.text()
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        """
+        Automatically close the client when being used as an async context manager.
+        """
+        await self.close()

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ passenv = *
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/tests/requirements.txt
 commands = python3 -B -m pytest {tty:--color=yes} {posargs} -v --mypy \
-           --cov=aiojenkins --cov=tests --cov-report=term --ignore docs
+           --cov=aiojenkins --asyncio-mode=auto --cov=tests --cov-report=term --ignore docs
 commands_post = rm -rf {toxinidir}/aiojenkins.egg-info
 allowlist_externals = rm
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from tests import get_host, get_password, get_user
 
 
 @pytest.fixture
-async def jenkins():  # pylint: disable=redefined-outer-name
+async def jenkins():
     async with Jenkins(get_host(), get_user(), get_password()) as client:
         yield client
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import pytest
 
 from aioresponses import aioresponses
@@ -9,23 +7,9 @@ from tests import get_host, get_password, get_user
 
 
 @pytest.fixture
-def event_loop():
-    loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()
-
-
-@pytest.fixture
-def jenkins(event_loop):  # pylint: disable=redefined-outer-name
-    async def _create_client():
-        return Jenkins(get_host(), get_user(), get_password())
-
-    async def _close_client():
-        await client.close()
-
-    client = event_loop.run_until_complete(_create_client())
-    yield client
-    event_loop.run_until_complete(_close_client())
+async def jenkins():  # pylint: disable=redefined-outer-name
+    async with Jenkins(get_host(), get_user(), get_password()) as client:
+        yield client
 
 
 @pytest.fixture

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -29,7 +29,7 @@ async def test_build_start(jenkins):
 @pytest.mark.asyncio
 async def test_build_list(jenkins):
     async with CreateJob(jenkins, parameters=[{'name': 'arg'}]) as job_name:
-        # TC: just created job must not has any builds
+        # TC: just created job must not have any builds
         builds = await jenkins.builds.get_all(job_name)
         assert len(builds) == 0
 

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -6,7 +6,6 @@ from aiojenkins.exceptions import JenkinsError
 from tests import CreateJob
 
 
-@pytest.mark.asyncio
 async def test_build_start(jenkins):
     arg_name = 'arg'
     arg_value = 'arg'
@@ -26,7 +25,6 @@ async def test_build_start(jenkins):
         assert build_info['actions'][0]['parameters'][0]['value'] == arg_value
 
 
-@pytest.mark.asyncio
 async def test_build_list(jenkins):
     async with CreateJob(jenkins, parameters=[{'name': 'arg'}]) as job_name:
         # TC: just created job must not have any builds
@@ -47,7 +45,6 @@ async def test_build_list(jenkins):
             assert len(output) > 0
 
 
-@pytest.mark.asyncio
 async def test_build_stop_delete(jenkins):
     job_config = {
         'parameters': [{'name': 'arg'}],
@@ -75,7 +72,6 @@ async def test_build_stop_delete(jenkins):
         await jenkins.builds.delete(job_name, 1)
 
 
-@pytest.mark.asyncio
 async def test_build_exists(jenkins):
     async with CreateJob(jenkins) as job_name:
         # TC: just created job hasn't any builds yet
@@ -88,7 +84,6 @@ async def test_build_exists(jenkins):
         assert (await jenkins.builds.is_exists(job_name, 1)) is True
 
 
-@pytest.mark.asyncio
 async def test_build_queue_id(jenkins):
     async with CreateJob(jenkins) as job_name:
         queue_id = await jenkins.builds.start(job_name)
@@ -98,7 +93,6 @@ async def test_build_queue_id(jenkins):
         assert isinstance(queue_id_info, dict) is True
 
 
-@pytest.mark.asyncio
 async def test_build_get_url_info(jenkins):
     # TC: invalid URL must raise the exception
     with pytest.raises(JenkinsError):

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -111,10 +111,22 @@ async def test_retry_client(monkeypatch):
 
     retry = {'total': 5, 'statuses': [HTTPStatus.INTERNAL_SERVER_ERROR]}
 
+    # Test using async context manager
     async with Jenkins(get_host(), get_user(), get_password(), retry=retry) as jenkins:
         await jenkins.get_status()
         monkeypatch.setattr('aiohttp.client.ClientSession.request', request)
         await jenkins.get_status()
+
+    monkeypatch.undo()
+
+    # Test using manual close
+    try:
+        jenkins = Jenkins(get_host(), get_user(), get_password(), retry=retry)
+        await jenkins.get_status()
+        monkeypatch.setattr('aiohttp.client.ClientSession.request', request)
+        await jenkins.get_status()
+    finally:
+        await jenkins.close()
 
 
 async def test_retry_validation():

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -11,19 +11,16 @@ from aiojenkins.jenkins import Jenkins, JenkinsVersion
 from tests import CreateJob, get_host, get_password, get_user, is_ci_server
 
 
-@pytest.mark.asyncio
 async def test_invalid_host(jenkins):
     with pytest.raises(JenkinsError):
         jenkins = Jenkins('@#$')
         await jenkins.get_version()
 
 
-@pytest.mark.asyncio
 async def test_get_status(jenkins):
     await jenkins.get_status()
 
 
-@pytest.mark.asyncio
 async def test_quiet_down(jenkins):
     await jenkins.quiet_down()
     server_status = await jenkins.get_status()
@@ -35,7 +32,6 @@ async def test_quiet_down(jenkins):
 
 
 @pytest.mark.skip
-@pytest.mark.asyncio
 async def test_restart(jenkins):
     if not is_ci_server():
         pytest.skip('takes too much time +40 seconds')
@@ -51,7 +47,6 @@ async def test_restart(jenkins):
     assert (await jenkins.is_ready()) is True
 
 
-@pytest.mark.asyncio
 async def test_tokens(jenkins):
     version = await jenkins.get_version()
 
@@ -76,7 +71,6 @@ async def test_tokens(jenkins):
             await jenkins_tokened.builds.start(job_name)
 
 
-@pytest.mark.asyncio
 async def test_run_groovy_script(jenkins):
     # TC: compare with expected result
     text = 'test'
@@ -88,7 +82,6 @@ async def test_run_groovy_script(jenkins):
     assert 'No such property' in response
 
 
-@pytest.mark.asyncio
 async def test_retry_client(monkeypatch):
     attempts = 0
 
@@ -118,17 +111,12 @@ async def test_retry_client(monkeypatch):
 
     retry = {'total': 5, 'statuses': [HTTPStatus.INTERNAL_SERVER_ERROR]}
 
-    try:
-        jenkins = Jenkins(get_host(), get_user(), get_password(), retry=retry)
-
+    async with Jenkins(get_host(), get_user(), get_password(), retry=retry) as jenkins:
         await jenkins.get_status()
         monkeypatch.setattr('aiohttp.client.ClientSession.request', request)
         await jenkins.get_status()
-    finally:
-        await jenkins.close()
 
 
-@pytest.mark.asyncio
 async def test_retry_validation():
     retry = {'attempts': 5, 'statuses': [HTTPStatus.INTERNAL_SERVER_ERROR]}
 
@@ -154,7 +142,6 @@ def test_session_close():
     gc.collect()
 
 
-@pytest.mark.asyncio
 async def test_make_jenkins_version(jenkins, aiohttp_mock):
     jenkins.crumb = False
 
@@ -184,5 +171,3 @@ async def test_make_jenkins_version(jenkins, aiohttp_mock):
     )
     version = await jenkins.get_version()
     assert version == JenkinsVersion(major=2, minor=346, patch=1, build=4)
-
-    await jenkins.close()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -29,7 +29,6 @@ FOLDER_CONFIG_XML = r"""<?xml version='1.1' encoding='UTF-8'?>
 """
 
 
-@pytest.mark.asyncio
 async def test_delete_job(jenkins):
     with contextlib.suppress(JenkinsNotFoundError):
         async with CreateJob(jenkins) as job_name:
@@ -38,21 +37,18 @@ async def test_delete_job(jenkins):
             assert job_name not in available_jobs
 
 
-@pytest.mark.asyncio
 async def test_create_job(jenkins):
     async with CreateJob(jenkins) as job_name:
         available_jobs = await jenkins.jobs.get_all()
         assert job_name in available_jobs
 
 
-@pytest.mark.asyncio
 async def test_get_job_config(jenkins):
     async with CreateJob(jenkins) as job_name:
         config = await jenkins.jobs.get_config(job_name)
         assert len(config) > 0
 
 
-@pytest.mark.asyncio
 async def test_get_job_reconfigure(jenkins):
     async with CreateJob(jenkins) as job_name:
         config_old = await jenkins.jobs.get_config(job_name)
@@ -67,7 +63,6 @@ async def test_get_job_reconfigure(jenkins):
         assert '<concurrentBuild>true</concurrentBuild>' in config
 
 
-@pytest.mark.asyncio
 async def test_disable_job(jenkins):
     async with CreateJob(jenkins) as job_name:
         await jenkins.jobs.disable(job_name)
@@ -75,13 +70,11 @@ async def test_disable_job(jenkins):
         assert job_info['color'] == 'disabled'
 
 
-@pytest.mark.asyncio
 async def test_disable_unavailable_job(jenkins):
     with pytest.raises(JenkinsNotFoundError):
         await jenkins.jobs.disable('unavailable')
 
 
-@pytest.mark.asyncio
 async def test_enable_job(jenkins):
     async with CreateJob(jenkins) as job_name:
         await jenkins.jobs.disable(job_name)
@@ -90,14 +83,12 @@ async def test_enable_job(jenkins):
         assert job_info['color'] != 'disabled'
 
 
-@pytest.mark.asyncio
 async def test_get_job_info(jenkins):
     async with CreateJob(jenkins) as job_name:
         info = await jenkins.jobs.get_info(job_name)
         assert isinstance(info, dict)
 
 
-@pytest.mark.asyncio
 async def test_copy_job(jenkins):
     async with CreateJob(jenkins) as job_name:
         job_name_new = job_name + '_new'
@@ -109,7 +100,6 @@ async def test_copy_job(jenkins):
             await jenkins.jobs.delete(job_name_new)
 
 
-@pytest.mark.asyncio
 async def test_rename_job(jenkins):
     async with CreateJob(jenkins) as job_name:
         job_name_new = job_name + '_new'
@@ -127,7 +117,6 @@ def test_construct_job_config(jenkins):
     assert len(jenkins.jobs.construct_config()) > 0
 
 
-@pytest.mark.asyncio
 async def test_job_exists(jenkins):
     # TC: unavailable job must not exist
     assert (await jenkins.jobs.is_exists(str(time.time_ns()))) is False
@@ -137,7 +126,6 @@ async def test_job_exists(jenkins):
         assert (await jenkins.jobs.is_exists(job_name)) is True
 
 
-@pytest.mark.asyncio
 async def test_folder(jenkins):
     plugins = await jenkins.plugins.get_all()
     if 'coudbees-folder' not in plugins:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -8,12 +8,10 @@ from aiojenkins.utils import construct_node_config
 from tests import CreateJob
 
 
-@pytest.mark.asyncio
 async def test_get_nodes(jenkins):
     await jenkins.nodes.get_all()
 
 
-@pytest.mark.asyncio
 async def test_get_node_info(jenkins):
     info = await jenkins.nodes.get_info('(master)')
     assert isinstance(info, dict)
@@ -21,7 +19,6 @@ async def test_get_node_info(jenkins):
     assert isinstance(info, dict)
 
 
-@pytest.mark.asyncio
 async def test_is_node_exists(jenkins):
     is_exists = await jenkins.nodes.is_exists('master')
     assert is_exists is True
@@ -33,7 +30,6 @@ async def test_is_node_exists(jenkins):
     assert is_exists is False
 
 
-@pytest.mark.asyncio
 async def test_disable_node(jenkins):
     for _ in range(2):
         await jenkins.nodes.disable('master')
@@ -41,7 +37,6 @@ async def test_disable_node(jenkins):
         assert info['offline'] is True
 
 
-@pytest.mark.asyncio
 async def test_enable_node(jenkins):
     for _ in range(2):
         await jenkins.nodes.enable('master')
@@ -49,7 +44,6 @@ async def test_enable_node(jenkins):
         assert info['offline'] is False
 
 
-@pytest.mark.asyncio
 async def test_update_node_offline_reason(jenkins):
     await jenkins.nodes.update_offline_reason('master', 'maintenance1')
     info = await jenkins.nodes.get_info('master')
@@ -60,7 +54,6 @@ async def test_update_node_offline_reason(jenkins):
     assert info['offlineCauseReason'] == 'maintenance2'
 
 
-@pytest.mark.asyncio
 async def test_get_node_config(jenkins):
     TEST_NODE_NAME = test_get_node_config.__name__
 
@@ -83,7 +76,6 @@ async def test_get_node_config(jenkins):
     await jenkins.nodes.delete(TEST_NODE_NAME)
 
 
-@pytest.mark.asyncio
 async def test_node_reconfigure(jenkins):
     TEST_NODE_NAME = test_node_reconfigure.__name__
 
@@ -110,7 +102,6 @@ async def test_node_reconfigure(jenkins):
     await jenkins.nodes.delete(TEST_NODE_NAME)
 
 
-@pytest.mark.asyncio
 async def test_node_reconfigure_master(jenkins):
     config = jenkins.nodes.construct(name='reconfigure_master')
 
@@ -118,7 +109,6 @@ async def test_node_reconfigure_master(jenkins):
         await jenkins.nodes.reconfigure('master', config)
 
 
-@pytest.mark.asyncio
 async def test_create_delete_node(jenkins):
     TEST_NODE_NAME = test_create_delete_node.__name__
 
@@ -141,7 +131,6 @@ async def test_create_delete_node(jenkins):
     assert TEST_NODE_NAME not in nodes_list
 
 
-@pytest.mark.asyncio
 async def test_get_all_builds(jenkins):
     node_name = 'master'
     await jenkins.nodes.enable(node_name)
@@ -156,7 +145,6 @@ async def test_get_all_builds(jenkins):
         assert builds[-1]['job_name'] == job_name
 
 
-@pytest.mark.asyncio
 async def test_get_failed_builds(jenkins):
     node_name = 'master'
     await jenkins.nodes.enable(node_name)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,7 +1,5 @@
-import pytest
 
 
-@pytest.mark.asyncio
 async def test_get_all_plugins(jenkins):
     plugins = await jenkins.plugins.get_all()
     assert len(plugins) >= 0

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,7 +1,5 @@
 import re
 
-import pytest
-
 QUEUE_JSON = """
 {
   "_class" : "hudson.model.Queue",
@@ -44,7 +42,6 @@ QUEUE_JSON = """
 }
 """
 
-
 QUEUE_ITEM_JSON = """
 {
   "_class" : "hudson.model.Queue$BlockedItem",
@@ -80,7 +77,6 @@ QUEUE_ITEM_JSON = """
 """
 
 
-@pytest.mark.asyncio
 async def test_get(jenkins, aiohttp_mock):
     aiohttp_mock.get(
         re.compile(r'.+/queue/api/json'),
@@ -93,7 +89,6 @@ async def test_get(jenkins, aiohttp_mock):
     assert len(queue) == 1
 
 
-@pytest.mark.asyncio
 async def test_get_info(jenkins, aiohttp_mock):
     aiohttp_mock.get(
         re.compile(r'.+/queue/item/\d+/api/json'),
@@ -106,7 +101,6 @@ async def test_get_info(jenkins, aiohttp_mock):
     assert item['stuck'] is False
 
 
-@pytest.mark.asyncio
 async def test_cancel(jenkins, aiohttp_mock):
     aiohttp_mock.post(
         re.compile(r'.+/queue/cancelItem'),

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -28,14 +28,12 @@ VIEW_CONFIG_XML = """<?xml version="1.0" encoding="UTF-8"?>
 """
 
 
-@pytest.mark.asyncio
 async def test_get_views(jenkins):
     views = await jenkins.views.get_all()
     assert len(views) > 0
     assert 'all' in map(lambda s: s.lower(), views)
 
 
-@pytest.mark.asyncio
 async def test_is_exists(jenkins):
     version = await jenkins.get_version()
 
@@ -45,7 +43,6 @@ async def test_is_exists(jenkins):
         assert await jenkins.views.is_exists('all') is True
 
 
-@pytest.mark.asyncio
 async def test_get_config(jenkins):
     version = await jenkins.get_version()
 
@@ -55,7 +52,6 @@ async def test_get_config(jenkins):
         assert len(await jenkins.views.get_config('all')) > 0
 
 
-@pytest.mark.asyncio
 async def test_view_create_delete(jenkins):
     await jenkins.views.create('test', VIEW_CONFIG_XML.format(name='test'))
 
@@ -70,7 +66,6 @@ async def test_view_create_delete(jenkins):
     assert 'test' not in views
 
 
-@pytest.mark.asyncio
 async def test_view_reconfigure(jenkins):
     with contextlib.suppress(JenkinsError):
         await jenkins.views.delete('test2')


### PR DESCRIPTION
I was using this for a project, and I didn't like having to write `try...finally: await jenkins.close()`.
This is the idiomatic way to setup/close resources such as this, and I'd love to see this merged/published to pypi if possible! Tests all pass locally (including with ~~3.7~~ 3.8, the minimum supported version of python for this project).